### PR TITLE
use del instead of gulp-clean

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@
 
 var gulp        = require('gulp'),
     gutil       = require('gulp-util'),
-    clean       = require('gulp-clean'),
+    del         = require('del'),
     yargs       = require('yargs').argv,
     shell       = require('gulp-shell'),
     fs          = require('fs'),
@@ -198,9 +198,9 @@ gulp.task('psi-mobile', function (cb) {
 --------------------------------------------------------------------------- */
 
 gulp.task('clean', function () {
-    return gulp
-        .src(['./css/', './js/', './results/'], {read: false})
-        .pipe(clean());
+    del(['./css/', './js/', './results/'], function (err) {
+        console.log('Directory cleaned.');
+    });
 });
 
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "cli-color": "~0.3.2",
+    "del": "^0.1.1",
     "gulp": "~3.8.0",
-    "gulp-clean": "^0.3.0",
     "gulp-csslint": "~0.1.4",
     "gulp-jshint": "~1.5.5",
     "gulp-shell": "^0.2.7",


### PR DESCRIPTION
`gulp-clean` is deprecated. Use `del` as alternative.
